### PR TITLE
Better compatibility with default DOOM modeline

### DIFF
--- a/naysayer-theme.el
+++ b/naysayer-theme.el
@@ -127,6 +127,10 @@
    `(powerline-inactive1 ((t (:background ,background :foreground ,text))))
    `(powerline-inactive2 ((t (:background ,background :foreground ,text))))
 
+    ;; better compatibility with default DOOM mode-line
+   `(error ((t (:foreground nil :weight normal))))
+   `(doom-modeline-project-dir ((t (:foreground nil :weight bold))))
+   
    ;; js2-mode
    `(js2-function-call ((t (:inherit (font-lock-function-name-face)))))
    `(js2-function-param ((t (:foreground ,text))))


### PR DESCRIPTION
These changes aim to improve text legibility in the modeline for both the project directory and the file path in a modified buffer when using Naysayer with DOOM Emacs (a very popular Emacs framework). Previously the project directory colour defaulted to a blueish-green that was difficult to read against Naysayer's tan-coloured modeline; in addition, the file path in a modified buffer changed to a light pink that was particularly illegible against the tan colour.

The text colour will now be the same as the rest of the foreground text in the modeline, which is the theme's behavior in Vanilla Emacs, and the text weighting will change in a modified buffer to subtly signify any unsaved changes. 

The revised theme was tested on both Doom Emacs (28.1) and Vanilla Emacs (28.1) - no issues were observed in either case.

Some of these problems were discussed in issue #5.