### PR TITLE
[impl] better color support in compilation buffer

### DIFF
--- a/naysayer-theme.el
+++ b/naysayer-theme.el
@@ -91,6 +91,20 @@
    `(line-number ((t (:foreground ,line-fg :background ,background))))
    `(line-number-current-line ((t (:foreground ,white :background ,background))))
 
+   ;; compilation
+   `(compilation-info ((t ,(list :foreground naysayer-theme-green
+                                 :inherit 'unspecified))))
+   `(compilation-warning ((t ,(list :foreground naysayer-theme-yellow
+                                    :bold t
+                                    :inherit 'unspecified))))
+   `(compilation-error ((t (:foreground, error))))
+   `(compilation-mode-line-fail ((t ,(list :foreground error
+                                           :weight 'bold
+                                           :inherit 'unspecified))))
+   `(compilation-mode-line-exit ((t ,(list :foreground naysayer-theme-green
+                                           :weight 'bold
+                                           :inherit 'unspecified))))
+
    ;; hl-line-mode
    `(hl-line ((t (:background ,highlight-line))))
    `(hl-line-face ((t (:background ,highlight-line))))


### PR DESCRIPTION
**Error message** highlighting in the `compilation mode` is missing in the current iteration. So, I've added the support. Here's a small comparison of that. 

### Before
![Image](https://github.com/user-attachments/assets/f957ad68-730e-43eb-8dc2-46e061017ca2)

### After
![Image](https://github.com/user-attachments/assets/88dd77ba-3187-4005-8a61-9fa3d6d8d18d)