### PR TITLE
nofeat: fix broken melpa link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Includes support for `rainbow-delimeters-mode`.
 
 ### With package.el
 
-Naysayer is available on [MELPA](http://melpa.milkbox.net).
+Naysayer is available on [MELPA](https://melpa.org).
 
 You can install `naysayer-theme` with: `M-x package-install naysayer-theme`
 


### PR DESCRIPTION
no idea what the original melpa link was in the README but it's definitely not the official link for MELPA